### PR TITLE
Highlight Explorer Loft on pricing page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -398,11 +398,35 @@ details p {
   border-radius: 18px;
   padding: 1.8rem;
   border: 1px solid rgba(58, 176, 162, 0.2);
+  position: relative;
 }
 
 .pricing-tier h3 {
   margin-top: 0;
   margin-bottom: 0.6rem;
+}
+
+.preferred-tier {
+  border-color: var(--primary);
+  background: linear-gradient(140deg, rgba(255, 209, 102, 0.38), rgba(58, 176, 162, 0.18));
+  box-shadow: 0 26px 48px rgba(176, 70, 36, 0.18);
+  transform: translateY(-8px);
+}
+
+.preferred-badge {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--primary);
+  color: #fff;
+  padding: 0.35rem 1.4rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 24px rgba(176, 70, 36, 0.25);
 }
 
 .price {
@@ -421,6 +445,19 @@ details p {
   margin: 1rem 0 0;
   padding-left: 1.2rem;
   color: var(--muted);
+}
+
+.currency-note {
+  margin-top: 0.8rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.availability-note {
+  margin: 0.4rem 0 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--primary-dark);
 }
 
 .quick-contact {

--- a/pricing.html
+++ b/pricing.html
@@ -32,20 +32,22 @@
       <div class="section-title">
         <h2>Overnight suites</h2>
         <p>All stays include daily habitat refresh, twilight play session, and signature bedtime treat plate.</p>
+        <p class="currency-note">All prices are listed in Canadian dollars (CAD).</p>
       </div>
       <div class="pricing-table">
         <article class="pricing-tier">
           <h3>Classic Burrow</h3>
-          <p class="price">$45 <span>/ night</span></p>
+          <p class="price">CA$45 <span>/ night</span></p>
           <ul class="extra-list">
             <li>Custom bedding &amp; wheel setup</li>
             <li>Nightly photo update</li>
             <li>Fresh veggie sampler</li>
           </ul>
         </article>
-        <article class="pricing-tier">
+        <article class="pricing-tier preferred-tier">
+          <span class="preferred-badge">Preferred</span>
           <h3>Explorer Loft</h3>
-          <p class="price">$59 <span>/ night</span></p>
+          <p class="price">CA$59 <span>/ night</span></p>
           <ul class="extra-list">
             <li>Split-level habitat with climbing wall</li>
             <li>Two enrichment sessions nightly</li>
@@ -54,7 +56,8 @@
         </article>
         <article class="pricing-tier">
           <h3>Royal Suite</h3>
-          <p class="price">$79 <span>/ night</span></p>
+          <p class="price">CA$79 <span>/ night</span></p>
+          <p class="availability-note">Subject to availability.</p>
           <ul class="extra-list">
             <li>Private play yard + scent garden</li>
             <li>Personal caretaker and spa service</li>
@@ -72,7 +75,7 @@
       <div class="pricing-table">
         <article class="pricing-tier">
           <h3>Sunrise stretch</h3>
-          <p class="price">$12 <span>/ session</span></p>
+          <p class="price">CA$12 <span>/ session</span></p>
           <ul class="extra-list">
             <li>Guided obstacle course and climb</li>
             <li>Post-play hydration and weigh-in</li>
@@ -80,7 +83,7 @@
         </article>
         <article class="pricing-tier">
           <h3>Forage fiesta</h3>
-          <p class="price">$15 <span>/ night</span></p>
+          <p class="price">CA$15 <span>/ night</span></p>
           <ul class="extra-list">
             <li>Hide-and-seek treat puzzle</li>
             <li>Seasonal herbs and safe flowers</li>
@@ -88,7 +91,7 @@
         </article>
         <article class="pricing-tier">
           <h3>Storytime stream</h3>
-          <p class="price">$9 <span>/ night</span></p>
+          <p class="price">CA$9 <span>/ night</span></p>
           <ul class="extra-list">
             <li>Bedtime story video call</li>
             <li>Digital scrapbook of the night</li>


### PR DESCRIPTION
## Summary
- highlight the Explorer Loft tier as the preferred option with a badge and enhanced styling
- update suite and add-on pricing copy to show Canadian dollars and add a currency note
- call out that the Royal Suite is subject to availability

## Testing
- Not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68cdaa12dfc0832592ef3d627b3df948