### PR TITLE
Improve quick contact CTA contrast

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -475,7 +475,10 @@ details p {
 
 .quick-contact a {
   font-weight: 600;
-  color: var(--primary);
+}
+
+.quick-contact .cta-button {
+  color: #fff;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- ensure the custom quote CTA in the pricing quick contact section keeps white text for readable contrast

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdad2feae883258c9cc1e72e8aa562